### PR TITLE
docs: fix broken Jupyter guide links

### DIFF
--- a/website/content/docs/index.md
+++ b/website/content/docs/index.md
@@ -12,7 +12,7 @@ This guide will help you get started with frictionless-ts. If you are new to the
 ## Runtimes
 
 > [!TIP]
-> - It is possible to use frictionless-ts in [Jupyter Notebooks](/guides/jupyter)!
+> - It is possible to use frictionless-ts in [Jupyter Notebooks](/frictionless-ts/guides/jupyter/)!
 
 frictionless-ts and all its packages support all the prominent TypeScript runtimes:
 

--- a/website/content/docs/overview/getting-started.md
+++ b/website/content/docs/overview/getting-started.md
@@ -10,7 +10,7 @@ This guide will help you get started with frictionless-ts. If you are new to the
 ## Runtimes
 
 > [!TIP]
-> - It is possible to use frictionless-ts in [Jupyter Notebooks](/guides/jupyter)!
+> - It is possible to use frictionless-ts in [Jupyter Notebooks](/frictionless-ts/guides/jupyter/)!
 
 frictionless-ts and all its packages support all the prominent TypeScript runtimes:
 


### PR DESCRIPTION
## Summary
- update Jupyter guide links to include the project base path (`/frictionless-ts`)
- apply fix in both docs pages where the same link appears:
  - `website/content/docs/index.md`
  - `website/content/docs/overview/getting-started.md`

## Why
The docs site is served under `/frictionless-ts`, so `/guides/jupyter` resolves outside the project docs and breaks.

Closes #11
